### PR TITLE
fix: sync RoleSwitch with external value

### DIFF
--- a/components/ui/RoleSwitch.tsx
+++ b/components/ui/RoleSwitch.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState } from "react";
 import clsx from "clsx";
 
 type Props = {
@@ -10,9 +10,13 @@ type Props = {
 
 export default function RoleSwitch({ value="admin", onChange, className }: Props){
   const [role, setRole] = useState<"admin"|"sponsor">(value);
-  const onChangeCb = useCallback((r: "admin"|"sponsor") => { onChange?.(r); }, [onChange]);
 
-  useEffect(() => { onChangeCb(role); }, [role, onChangeCb]);
+  useEffect(() => { setRole(value); }, [value]);
+
+  const handleChange = (r: "admin"|"sponsor") => {
+    setRole(r);
+    onChange?.(r);
+  };
 
   return (
     <div className={clsx("pill lumen w-[360px] h-14 p-1 flex items-center gap-1", className)}>
@@ -21,7 +25,7 @@ export default function RoleSwitch({ value="admin", onChange, className }: Props
           "flex-1 h-12 rounded-[12px] transition",
           role === "admin" ? "bg-[var(--accent)] text-white shadow-[var(--halo)]" : "text-[var(--text)] hover:bg-[var(--surface)]"
         )}
-        onClick={() => setRole("admin")}
+        onClick={() => handleChange("admin")}
       >
         Admin
       </button>
@@ -30,7 +34,7 @@ export default function RoleSwitch({ value="admin", onChange, className }: Props
           "flex-1 h-12 rounded-[12px] transition",
           role === "sponsor" ? "bg-[var(--accent)] text-white shadow-[var(--halo)]" : "text-[var(--text)] hover:bg-[var(--surface)]"
         )}
-        onClick={() => setRole("sponsor")}
+        onClick={() => handleChange("sponsor")}
       >
         Patrocinador
       </button>


### PR DESCRIPTION
## Summary
- fix RoleSwitch component to update when its `value` prop changes
- notify parent only on user interaction

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cf78b51448327ba8b40ae91083536